### PR TITLE
Add number separator option

### DIFF
--- a/Core/CurrenciesCore.lua
+++ b/Core/CurrenciesCore.lua
@@ -63,6 +63,7 @@ function L.PrepareCurrenciesMenuBase(eddm, self, id, hasMax)
 	eddm.UIDropDownMenu_AddButton(CreateTitle(id, L["tooltip"]));
 	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["showAltText"], "ShowAltText"));
 	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["sortByAmount"], "AltTextSortByAmount"));
+	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["addDigitSeparator"], "AddSeparator"));
 	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["showAllFactions"], "ShowAllFactions"));
 	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["useHyperlink"], "UseHyperlink"));
 	eddm.UIDropDownMenu_AddButton(CreateToggle(id, L["hideInfoWhenHyperlink"], "HideInfoWhenHyperlink"));

--- a/Core/SimpleCurrencyPlugin.lua
+++ b/Core/SimpleCurrencyPlugin.lua
@@ -77,28 +77,32 @@ function L:CreateSimpleCurrencyPlugin(params)
 	}
 	-----------------------------------------------
 	local function GetButtonText()
-		local currencyCountText = TitanUtils_GetHighlightText(currencyCount or "0")
+		local AddSeparator = TitanGetVar(params.titanId, "AddSeparator")
+		local currencyCountText = TitanUtils_GetHighlightText(AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0"))
 		if currencyCount and currencyMaximum > 0 then
+			local currencyCountText = AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0")
 			if currencyCount > currencyMaximum * 0.4 and currencyCount < currencyMaximum * 0.59 then
-				currencyCountText = "|cFFf6ed12" .. currencyCount
+				currencyCountText = "|cFFf6ed12" .. currencyCountText
 			elseif currencyCount > currencyMaximum * 0.59 and currencyCount < currencyMaximum * 0.79 then
-				currencyCountText = "|cFFf69112" .. currencyCount
+				currencyCountText = "|cFFf69112" .. currencyCountText
 			elseif currencyCount > currencyMaximum * 0.79 then
-				currencyCountText = "|cFFFF2e2e" .. currencyCount
+				currencyCountText = "|cFFFF2e2e" .. currencyCountText
 			end
 		end
 
 		local maxBarText = ""
 		if currencyMaximum and currencyMaximum > 0 and TitanGetVar(params.titanId, "MaxBar") then
-			maxBarText = "|r/|cFFFF2e2e" .. currencyMaximum .. "|r"
+			maxBarText = "|r/|cFFFF2e2e" .. (AddSeparator and BreakUpLargeNumbers(currencyMaximum) or currencyMaximum) .. "|r"
 		end
 
 		local barBalanceText = ""
 		if TitanGetVar(params.titanId, "ShowBarBalance") then
-			if (currencyCount - startcurrency) > 0 then
-				barBalanceText = " |cFF69FF69[" .. (currencyCount - startcurrency) .. "]"
+			local delta = (currencyCount - startcurrency)
+			local deltaText = AddSeparator and BreakUpLargeNumbers(delta) or delta
+			if delta > 0 then
+				barBalanceText = " |cFF69FF69[" .. deltaText .. "]"
 			elseif (currencyCount - startcurrency) < 0 then
-				barBalanceText = " |cFFFF2e2e[" .. (currencyCount - startcurrency) .. "]"
+				barBalanceText = " |cFFFF2e2e[" .. deltaText .. "]"
 			end
 		end
 
@@ -117,27 +121,33 @@ function L:CreateSimpleCurrencyPlugin(params)
 			GameTooltip:AddLine(CURRENCY_NAME, 1, 1, 1)
 		end
 
+		local AddSeparator = TitanGetVar(params.titanId, "AddSeparator")
 		GameTooltip:AddLine(" ")
 		GameTooltip:AddLine(L["info"])
 
 		if not currencyCount or currencyCount == 0 then
 			GameTooltip:AddLine("|cFFFF2e2e" .. params.noCurrencyText)
 		else
-			GameTooltip:AddDoubleLine(L["totalAcquired"], TitanUtils_GetHighlightText(currencyCount))
+			local currentText = AddSeparator and BreakUpLargeNumbers(currencyCount) or currencyCount
+
+			GameTooltip:AddDoubleLine(L["totalAcquired"], TitanUtils_GetHighlightText(currentText))
 			if (currencyMaximum and currencyMaximum > 0) then
-				GameTooltip:AddDoubleLine(L["maxpermitted"], TitanUtils_GetHighlightText(currencyMaximum))
-				GameTooltip:AddDoubleLine(L["canGet"], TitanUtils_GetHighlightText((currencyMaximum - currencyCount)))
+				local maxText = AddSeparator and BreakUpLargeNumbers(currencyMaximum) or currencyMaximum
+				local canGetText = AddSeparator and BreakUpLargeNumbers((currencyMaximum - currencyCount)) or (currencyMaximum - currencyCount)
+				GameTooltip:AddDoubleLine(L["maxpermitted"], TitanUtils_GetHighlightText(maxText))
+				GameTooltip:AddDoubleLine(L["canGet"], TitanUtils_GetHighlightText(canGetText))
 			end
 
 			local sessionValueText = "0" -- Cores da conta de valor
 			if currencyCount and startcurrency then
 				local dif = currencyCount - startcurrency
+				local difText = AddSeparator and BreakUpLargeNumbers(dif) or dif
 				if dif == 0 then
 					sessionValueText = TitanUtils_GetHighlightText("0")
 				elseif dif > 0 then
-					sessionValueText = "|cFF69FF69" .. dif
+					sessionValueText = "|cFF69FF69" .. difText
 				else
-					sessionValueText = "|cFFFF2e2e" .. dif
+					sessionValueText = "|cFFFF2e2e" .. difText
 				end
 			end
 
@@ -161,12 +171,14 @@ function L:CreateSimpleCurrencyPlugin(params)
 				if isCurrent or ((showAllFactions or PLAYER_FACTION == v.faction) and (v.currency or 0) > 0) then
 					local arrow = isCurrent and "> " or ""
 					local arrowEnd = isCurrent and "|r <" or ""
-					GameTooltip:AddDoubleLine(arrow .. v.name .. arrowEnd, "|cFFFFFFFF" .. (v.currency))
+					local amountText = AddSeparator and BreakUpLargeNumbers(v.currency) or v.currency
+
+					GameTooltip:AddDoubleLine(arrow .. v.name .. arrowEnd, "|cFFFFFFFF" .. (amountText))
 					total = total + v.currency
 				end
 			end
 
-			GameTooltip:AddDoubleLine(L["TotalAlt"], total)
+			GameTooltip:AddDoubleLine(L["TotalAlt"], AddSeparator and BreakUpLargeNumbers(total) or total)
 		end
 	end
 
@@ -199,6 +211,7 @@ function L:CreateSimpleCurrencyPlugin(params)
 			MaxBar = ifZero(currencyMaximum, nil, false),
 			UseHyperlink = true,
 			HideInfoWhenHyperlink = false,
+			AddSeparator= false,
 		}
 	})
 

--- a/Core/SimpleItemPlugin.lua
+++ b/Core/SimpleItemPlugin.lua
@@ -78,14 +78,17 @@ function L:CreateSimpleItemPlugin(params)
 	}
 
 	local function GetButtonText()
-		local currencyCountText = TitanUtils_GetHighlightText(currencyCount)
+		local AddSeparator = TitanGetVar(params.titanId, "AddSeparator")
+		local currencyCountText = TitanUtils_GetHighlightText(AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0"))
 
 		local barBalanceText = ""
 		if TitanGetVar(params.titanId, "ShowBarBalance") then
-			if (currencyCount - startcurrency) > 0 then
-				barBalanceText = " |cFF69FF69[" .. (currencyCount - startcurrency) .. "]"
+			local delta = (currencyCount - startcurrency)
+			local deltaText = AddSeparator and BreakUpLargeNumbers(delta) or delta
+			if delta > 0 then
+				barBalanceText = " |cFF69FF69[" .. deltaText .. "]"
 			elseif (currencyCount - startcurrency) < 0 then
-				barBalanceText = " |cFFFF2e2e[" .. (currencyCount - startcurrency) .. "]"
+				barBalanceText = " |cFFFF2e2e[" .. deltaText .. "]"
 			end
 		end
 
@@ -104,6 +107,7 @@ function L:CreateSimpleItemPlugin(params)
 			GameTooltip:AddLine(itemMixin:GetItemName(), 1, 1, 1)
 		end
 
+		local AddSeparator = TitanGetVar(params.titanId, "AddSeparator")
 		GameTooltip:AddLine(" ")
 		GameTooltip:AddLine(L["info"])
 
@@ -111,21 +115,23 @@ function L:CreateSimpleItemPlugin(params)
 			GameTooltip:AddLine("|cFFFF2e2e" .. params.noCurrencyText)
 		else
 			local bag = GetItemCount(params.itemId)
-			local total = GetItemCount(params.itemId, true)
-			local bank = total - bag
+			local bank = GetItemCount(params.itemId, true) - bag
+			local bagText = AddSeparator and BreakUpLargeNumbers(bag) or bag
+			local bankText = AddSeparator and BreakUpLargeNumbers(bank) or bank
 
-			GameTooltip:AddDoubleLine(L["totalbag"], TitanUtils_GetHighlightText(bag))
-			GameTooltip:AddDoubleLine(L["totalbank"], TitanUtils_GetHighlightText(bank))
+			GameTooltip:AddDoubleLine(L["totalbag"], TitanUtils_GetHighlightText(bagText))
+			GameTooltip:AddDoubleLine(L["totalbank"], TitanUtils_GetHighlightText(bankText))
 
 			local sessionValueText = "0" -- Cores da conta de valor
 			if currencyCount and startcurrency then
 				local dif = currencyCount - startcurrency
+				local difText = AddSeparator and BreakUpLargeNumbers(dif) or dif
 				if dif == 0 then
 					sessionValueText = TitanUtils_GetHighlightText("0")
 				elseif dif > 0 then
-					sessionValueText = "|cFF69FF69" .. dif
+					sessionValueText = "|cFF69FF69" .. difText
 				else
-					sessionValueText = "|cFFFF2e2e" .. dif
+					sessionValueText = "|cFFFF2e2e" .. difText
 				end
 			end
 
@@ -149,12 +155,14 @@ function L:CreateSimpleItemPlugin(params)
 				if isCurrent or ((showAllFactions or PLAYER_FACTION == v.faction) and (v.currency or 0) > 0) then
 					local arrow = isCurrent and "> " or ""
 					local arrowEnd = isCurrent and "|r <" or ""
-					GameTooltip:AddDoubleLine(arrow .. v.name .. arrowEnd, "|cFFFFFFFF" .. (v.currency))
+					local amountText = AddSeparator and BreakUpLargeNumbers(v.currency) or v.currency
+
+					GameTooltip:AddDoubleLine(arrow .. v.name .. arrowEnd, "|cFFFFFFFF" .. (amountText))
 					total = total + v.currency
 				end
 			end
 
-			GameTooltip:AddDoubleLine(L["TotalAlt"], total)
+			GameTooltip:AddDoubleLine(L["TotalAlt"], AddSeparator and BreakUpLargeNumbers(total) or total)
 		end
 	end
 
@@ -179,6 +187,7 @@ function L:CreateSimpleItemPlugin(params)
 			ShowAllFactions = false,
 			UseHyperlink = true,
 			HideInfoWhenHyperlink = false,
+			AddSeparator= false,
 		},
 		afterLoad = function(self)
 			itemMixin:ContinueOnItemLoad(function()

--- a/Core/languages/enUS-default.lua
+++ b/Core/languages/enUS-default.lua
@@ -170,6 +170,7 @@ L["showAllFactions"] = "Characters from Both Factions"
 L["useHyperlink"] = "Show tooltip as hyperlink"
 L["hideInfoWhenHyperlink"] = "Hide extra info when showing hyperlink"
 L["sortByAmount"] = "Sort by amount"
+L["addDigitSeparator"] = "Add thousands separator for large numbers"
 
 --- Menus
 L["bfa"] = "Currency [BfA]"


### PR DESCRIPTION
This adds the option to have add the thousands separator (localized) added to the buttons as well as tooltips for the simple types that are tracked.


i.e. `1000` becomes `1,000` for me in the US.
