### PR TITLE
 Addresses the "show max on bar" preference not loading the first time you log in

### DIFF
--- a/Core/SimpleCurrencyPlugin.lua
+++ b/Core/SimpleCurrencyPlugin.lua
@@ -26,8 +26,8 @@ function L:CreateSimpleCurrencyPlugin(params)
 	local useTotalEarnedForMaxQty = currencyInfoBase.useTotalEarnedForMaxQty
 	local totalSeasonalEarned = currencyInfoBase.totalEarned
 	-- For whatever reason, the value can be nil when the plugin first loads
-	-- If you know that the currency has a maximum, then allow the creator to force it to be treated as if it had a max.
-	local forceMax = params.forceMax
+	-- If the creator knows that the currency has a maximum, then allow them to force it to be treated as if it had a max.
+	local forceMax = params.forceMax or false
 
 	local PLAYER_NAME, PLAYER_REALM
 	local PLAYER_KEY

--- a/Core/SimpleCurrencyPlugin.lua
+++ b/Core/SimpleCurrencyPlugin.lua
@@ -22,7 +22,12 @@ function L:CreateSimpleCurrencyPlugin(params)
 	local currencyInfoBase = C_CurrencyInfo.GetCurrencyInfo(params.currencyId)
 	local ICON = currencyInfoBase.iconFileID
 	local CURRENCY_NAME = currencyInfoBase.name
-	local currencyMaximum = currencyInfoBase.maxQuantity
+	local currencyMaximum = currencyInfoBase.maxQuantity or 0
+	local useTotalEarnedForMaxQty = currencyInfoBase.useTotalEarnedForMaxQty
+	local totalSeasonalEarned = currencyInfoBase.totalEarned
+	-- For whatever reason, the value can be nil when the plugin first loads
+	-- If you know that the currency has a maximum, then allow the creator to force it to be treated as if it had a max.
+	local forceMax = params.forceMax
 
 	local PLAYER_NAME, PLAYER_REALM
 	local PLAYER_KEY
@@ -44,6 +49,9 @@ function L:CreateSimpleCurrencyPlugin(params)
 		charTable[PLAYER_KEY].name = PLAYER_CLASS_COLOR .. PLAYER_NAME
 		charTable[PLAYER_KEY].faction = PLAYER_FACTION
 
+		-- Make sure these values are up to date, since they can be wrong when the addon first loads
+		useTotalEarnedForMaxQty = info.useTotalEarnedForMaxQty
+		totalSeasonalEarned = info.totalEarned
 		return amount, totalMax
 	end
 
@@ -79,20 +87,25 @@ function L:CreateSimpleCurrencyPlugin(params)
 	local function GetButtonText()
 		local AddSeparator = TitanGetVar(params.titanId, "AddSeparator")
 		local currencyCountText = TitanUtils_GetHighlightText(AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0"))
-		if currencyCount and currencyMaximum > 0 then
-			local currencyCountText = AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0")
-			if currencyCount > currencyMaximum * 0.4 and currencyCount < currencyMaximum * 0.59 then
+		if (currencyCount or totalSeasonalEarned) and currencyMaximum > 0 then
+			local maxCheckCurrency = (useTotalEarnedForMaxQty and totalSeasonalEarned) or currencyCount
+			currencyCountText = AddSeparator and BreakUpLargeNumbers(currencyCount) or (currencyCount or "0")
+			if maxCheckCurrency > currencyMaximum * 0.4 and maxCheckCurrency < currencyMaximum * 0.59 then
 				currencyCountText = "|cFFf6ed12" .. currencyCountText
-			elseif currencyCount > currencyMaximum * 0.59 and currencyCount < currencyMaximum * 0.79 then
+			elseif maxCheckCurrency > currencyMaximum * 0.59 and maxCheckCurrency < currencyMaximum * 0.79 then
 				currencyCountText = "|cFFf69112" .. currencyCountText
-			elseif currencyCount > currencyMaximum * 0.79 then
+			elseif maxCheckCurrency > currencyMaximum * 0.79 then
 				currencyCountText = "|cFFFF2e2e" .. currencyCountText
 			end
 		end
 
 		local maxBarText = ""
 		if currencyMaximum and currencyMaximum > 0 and TitanGetVar(params.titanId, "MaxBar") then
-			maxBarText = "|r/|cFFFF2e2e" .. (AddSeparator and BreakUpLargeNumbers(currencyMaximum) or currencyMaximum) .. "|r"
+			local localMaxValue = (useTotalEarnedForMaxQty and totalEarned) or currencyMaximum
+			local canEarnText = (AddSeparator and BreakUpLargeNumbers(localMaxValue - totalSeasonalEarned)) or (localMaxValue - totalSeasonalEarned)
+						canEarnText = (useTotalEarnedForMaxQty and (" [" .. canEarnText .. "]")) or ""
+			maxBarText = "|r/|cFFFF2e2e" .. (AddSeparator and BreakUpLargeNumbers(currencyMaximum) or currencyMaximum)
+			maxBarText = maxBarText .. canEarnText .. "|r"
 		end
 
 		local barBalanceText = ""
@@ -132,8 +145,9 @@ function L:CreateSimpleCurrencyPlugin(params)
 
 			GameTooltip:AddDoubleLine(L["totalAcquired"], TitanUtils_GetHighlightText(currentText))
 			if (currencyMaximum and currencyMaximum > 0) then
-				local maxText = AddSeparator and BreakUpLargeNumbers(currencyMaximum) or currencyMaximum
-				local canGetText = AddSeparator and BreakUpLargeNumbers((currencyMaximum - currencyCount)) or (currencyMaximum - currencyCount)
+				local localCountValue = (useTotalEarnedForMaxQty and totalSeasonalEarned) or currencyCount
+				local maxText = (AddSeparator and BreakUpLargeNumbers(currencyMaximum)) or currencyMaximum
+				local canGetText = (AddSeparator and BreakUpLargeNumbers(currencyMaximum - localCountValue)) or (currencyMaximum - localCountValue)
 				GameTooltip:AddDoubleLine(L["maxpermitted"], TitanUtils_GetHighlightText(maxText))
 				GameTooltip:AddDoubleLine(L["canGet"], TitanUtils_GetHighlightText(canGetText))
 			end
@@ -188,6 +202,12 @@ function L:CreateSimpleCurrencyPlugin(params)
 		end
 		return resultElse
 	end
+	local prepMenu = ifZero(currencyMaximum, L.PrepareCurrenciesMenu, L.PrepareCurrenciesMaxMenu)
+	maxBarValue = ifZero(currencyMaximum, nil, false)
+	if forceMax then
+		prepMenu = L.PrepareCurrenciesMaxMenu
+		maxBarValue = 1
+	end
 
 	L.Elib({
 		id = params.titanId,
@@ -199,7 +219,7 @@ function L:CreateSimpleCurrencyPlugin(params)
 		version = version,
 		getButtonText = GetButtonText,
 		eventsTable = eventsTable,
-		prepareMenu = ifZero(currencyMaximum, L.PrepareCurrenciesMenu, L.PrepareCurrenciesMaxMenu),
+		prepareMenu = prepMenu,
 		savedVariables = {
 			ShowIcon = 1,
 			DisplayOnRightSide = false,
@@ -208,7 +228,7 @@ function L:CreateSimpleCurrencyPlugin(params)
 			ShowAltText = true,
 			AltTextSortByAmount = false,
 			ShowAllFactions = false,
-			MaxBar = ifZero(currencyMaximum, nil, false),
+			MaxBar = maxBarValue,
 			UseHyperlink = true,
 			HideInfoWhenHyperlink = false,
 			AddSeparator= false,

--- a/TitanCurrenciesMulti.toc
+++ b/TitanCurrenciesMulti.toc
@@ -32,6 +32,7 @@ c.Dragonflight\TitanDGlyphEmbers.lua
 c.Dragonflight\TitanDilatedTimePod.lua
 c.Dragonflight\TitanDISupplies.lua
 c.Dragonflight\TitanDrakesDreamingCrest.lua
+c.Dragonflight\TitanDreamEnergy.lua
 c.Dragonflight\TitanDreamInfusion.lua
 c.Dragonflight\TitanDreamsurgeCoalescence.lua
 c.Dragonflight\TitanDreamsurgeCocoon.lua

--- a/c.Dragonflight/TitanDrakesDreamingCrest.lua
+++ b/c.Dragonflight/TitanDrakesDreamingCrest.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your  Drake's Dreaming Crests.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.
@@ -14,5 +14,6 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = ID,
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
-	category = "CATEGORY_DRAGON"
+	category = "CATEGORY_DRAGON",
+	forceMax = true
 })

--- a/c.Dragonflight/TitanDreamEnergy.lua
+++ b/c.Dragonflight/TitanDreamEnergy.lua
@@ -1,13 +1,13 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your  Aspect's Dreaming Crests.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.
 --]]
 
 local _, L = ...;
-local ID = "TITAN_ASPECTDREAMINGCREST"
-local CURRENCY_ID = 2709
+local ID = "TITAN_DREAMENERGY"
+local CURRENCY_ID = 2649
 
 L:CreateSimpleCurrencyPlugin({
 	currencyId = CURRENCY_ID,

--- a/c.Dragonflight/TitanDreamInfusion.lua
+++ b/c.Dragonflight/TitanDreamInfusion.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Dream Infusions.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.

--- a/c.Dragonflight/TitanEmeraldDewdrop.lua
+++ b/c.Dragonflight/TitanEmeraldDewdrop.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Emerald Dewdrops.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.

--- a/c.Dragonflight/TitanSeedbloom.lua
+++ b/c.Dragonflight/TitanSeedbloom.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Seedblooms.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.
@@ -7,10 +7,19 @@ Special Thanks to Protuhj.
 
 local _, L = ...;
 local ID = "TITAN_SEEDBLOOM"
-local CURRENCY_ID = 2651
+local ITEM_ID = 211376
+-- Currency seems unused?
+--local CURRENCY_ID = 2651
 
-L:CreateSimpleCurrencyPlugin({
-	currencyId = CURRENCY_ID,
+--L:CreateSimpleCurrencyPlugin({
+--	currencyId = CURRENCY_ID,
+--	titanId = ID,
+--	noCurrencyText = L["DragonFOnly"],
+--	expName = L["mDragonflight"],
+--	category = "CATEGORY_DRAGON"
+--})
+L:CreateSimpleItemPlugin({
+	itemId = ITEM_ID,
 	titanId = ID,
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],

--- a/c.Dragonflight/TitanWhelplingsDreamingCrest.lua
+++ b/c.Dragonflight/TitanWhelplingsDreamingCrest.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Whelpling's Dreaming Crests.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.
@@ -14,5 +14,6 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = ID,
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
-	category = "CATEGORY_DRAGON"
+	category = "CATEGORY_DRAGON",
+	forceMax = true
 })

--- a/c.Dragonflight/TitanWyrmsDreamingCrest.lua
+++ b/c.Dragonflight/TitanWyrmsDreamingCrest.lua
@@ -1,5 +1,5 @@
 --[[
-Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your Paracausal Flakes.
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your  Wyrm's Dreaming Crests.
 Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
 Author: Canettieri
 Special Thanks to Protuhj.
@@ -14,5 +14,6 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = ID,
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
-	category = "CATEGORY_DRAGON"
+	category = "CATEGORY_DRAGON",
+	forceMax = true
 })


### PR DESCRIPTION
Currencies can now give the simple currency plugin a hint (called `forceMax`) to configure the currency as if it has a max value, since when you first load, the value you get from the WoW API can say it doesn't have a max.

Also fixed the "can get" amount on the tooltip, since seasonal currencies have a moving maximum.

Also added the "can get" value to the bar when showing the max value, currently this value is in square brackets "[ ]"

![image](https://github.com/Canettieri/currenciesmulti/assets/1165219/0367103a-1cd3-438d-9584-524073092188)

In the image, the two values without the "can get" amount don't increase each week.
The "can get" values are also only shown if you choose to show the max value on the bar.

I'm open to suggestions on maybe making that display better if you feel it's too much.