### PR TITLE
Basically reverse coloring logic for seasonal currencies

### DIFF
--- a/c.Dragonflight/TitanAspectsDreamingCrest.lua
+++ b/c.Dragonflight/TitanAspectsDreamingCrest.lua
@@ -15,5 +15,6 @@ L:CreateSimpleCurrencyPlugin({
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
 	category = "CATEGORY_DRAGON",
-	forceMax = true
+	forceMax = true,
+	weeklyIncrease = 90
 })

--- a/c.Dragonflight/TitanDrakesDreamingCrest.lua
+++ b/c.Dragonflight/TitanDrakesDreamingCrest.lua
@@ -15,5 +15,6 @@ L:CreateSimpleCurrencyPlugin({
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
 	category = "CATEGORY_DRAGON",
-	forceMax = true
+	forceMax = true,
+	weeklyIncrease = 90
 })

--- a/c.Dragonflight/TitanWhelplingsDreamingCrest.lua
+++ b/c.Dragonflight/TitanWhelplingsDreamingCrest.lua
@@ -15,5 +15,6 @@ L:CreateSimpleCurrencyPlugin({
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
 	category = "CATEGORY_DRAGON",
-	forceMax = true
+	forceMax = true,
+	weeklyIncrease = 90
 })

--- a/c.Dragonflight/TitanWyrmsDreamingCrest.lua
+++ b/c.Dragonflight/TitanWyrmsDreamingCrest.lua
@@ -15,5 +15,6 @@ L:CreateSimpleCurrencyPlugin({
 	noCurrencyText = L["DragonFOnly"],
 	expName = L["mDragonflight"],
 	category = "CATEGORY_DRAGON",
-	forceMax = true
+	forceMax = true,
+	weeklyIncrease = 90
 })


### PR DESCRIPTION
With regards to #31 -- the coloring of the current amount of currency will be based on how much you can still earn.

I added a new field to the crests that allows new currencies to tell how much they increase weekly, when inevitably new ones get added.

You can see the scheme in action here:

![image](https://github.com/Canettieri/currenciesmulti/assets/1165219/0986866e-b829-45ea-92b5-bbff302ce41c)

Thoughts?