### PR TITLE
[CATA] Update for Molten Front

### DIFF
--- a/TitanCurrenciesMulti_Cata.toc
+++ b/TitanCurrenciesMulti_Cata.toc
@@ -28,6 +28,7 @@ c.Legacy\Cataclysm\TitanChefAward.lua
 c.Legacy\Cataclysm\TitanIllustriousJCToken.lua
 c.Legacy\Cataclysm\TitanJusticePoints.lua
 c.Legacy\Cataclysm\TitanValorPoints.lua
+c.Legacy\Cataclysm\TitanMarkWorldTree.lua
 c.Legacy\WotLK\TitanArenaPoints.lua
 c.Legacy\WotLK\TitanBadgeofJustice.lua
 c.Legacy\WotLK\TitanChampionsSeal.lua

--- a/c.Legacy/Cataclysm/TitanMarkWorldTree.lua
+++ b/c.Legacy/Cataclysm/TitanMarkWorldTree.lua
@@ -14,5 +14,5 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = ID,
 	noCurrencyText = L["NoWorldTree"],
 	expName = L["mCata"],
-	category = "CATEGORY_LEGACY"
+	category = "CATEGORY_CATA"
 })


### PR DESCRIPTION
Now that Molten Front dailies are unlocked we have access to Mark of the World Tree. This PR adds the corresponding lua entry back into the Cata TOC and fixes the category so that it shows up in the Cata currencies in Titan.