### PR TITLE
Update for Cata Fissure Stone Fragments

### DIFF
--- a/Core/languages/enUS-default.lua
+++ b/Core/languages/enUS-default.lua
@@ -129,6 +129,8 @@ L["NoBloody"] = "Available using |cff0070ddCenser of\rEternal Agony|r|cFFFF2e2e 
 L["NoIronpaw"] = "Available through cooking quests in Pandaria."
 --- Mark of the World Tree
 L["NoWorldTree"] = "Available through daily\rquests in Mount Hyjal."
+--- Fissure Stone Fragment
+L["NoFissStone"] = "Available through Protocol Inferno Heroic Dungeons."
 --- Timeless Coin
 L["NoTimeless"] = "Available through Timeless Isle."
 

--- a/Core/languages/frFR.lua
+++ b/Core/languages/frFR.lua
@@ -66,6 +66,8 @@ L["NoEpicurean"] = "Disponible via les quêtes de cuisine dans le vieux Dalaran\
 L["NoIronpaw"] = "Disponible via les quêtes de cuisine de la Pandarie."
 --- Mark of the World Tree
 L["NoWorldTree"] = "Disponible via les quêtes journalières du Mont Hyjal."
+--- Fissure Stone Fragment
+L["NoFissStone"] = "Disponible via Protocole Inferno Donjons héroïques"
 --- Timeless Coin
 L["NoTimeless"] = "Disponible sur l’île du Temps figé."
 

--- a/TitanCurrenciesMulti_Cata.toc
+++ b/TitanCurrenciesMulti_Cata.toc
@@ -1,4 +1,4 @@
-## Interface: 40400
+## Interface: 40401
 ## Title: Titan Panel [|cff336699Currencies|r] Multi! |cff00aa00@project-version@|r
 ## Notes: Track a lot of currencies! Right-click on Titan Panel, go to "Information" tab and enjoy.
 ## Notes-ptBR: Rastreie várias moedas! Clique com o botão direito no Painel Titan, vá na aba "Informação" e aproveite.
@@ -28,6 +28,7 @@ c.Legacy\Cataclysm\TitanChefAward.lua
 c.Legacy\Cataclysm\TitanIllustriousJCToken.lua
 c.Legacy\Cataclysm\TitanJusticePoints.lua
 c.Legacy\Cataclysm\TitanMarkWorldTree.lua
+c.Legacy\Cataclysm\TitanFissureStoneFragment.lua
 c.Legacy\Cataclysm\TitanValorPoints.lua
 c.Legacy\WotLK\TitanArenaPoints.lua
 c.Legacy\WotLK\TitanBadgeofJustice.lua

--- a/c.Legacy/Cataclysm/TitanFissureStoneFragment.lua
+++ b/c.Legacy/Cataclysm/TitanFissureStoneFragment.lua
@@ -1,0 +1,18 @@
+--[[
+Description: This plugin is part of the "Titan Panel [Currencies] Multi" addon. It shows your amount of Fissure Stone Fragments.
+Site: https://www.curseforge.com/wow/addons/titan-panel-currencies-multi
+Author: Canettieri
+Special Thanks to Eliote.
+--]]
+
+local _, L = ...;
+local ID = "TITAN_FSFRGM"
+local CURRENCY_ID = 3148
+
+L:CreateSimpleCurrencyPlugin({
+	currencyId = CURRENCY_ID,
+	titanId = ID,
+	noCurrencyText = L["NoFissStone"],
+	expName = L["mCata"],
+	category = (LE_EXPANSION_LEVEL_CURRENT <= LE_EXPANSION_CATACLYSM) and "CATEGORY_CATA" or "CATEGORY_LEGACY"
+})


### PR DESCRIPTION
New Cata patch 4.4.1 introduces Fissure Stone Fragments from Inferno Protocol Heroic's.

Added the relevant Fissure Stone Fragment into Legacy>Cata
Updated Cata toc to load this file and bumped to 40401
Added translation to enUS and frFR