### PR TITLE
Opens the currency tab when a currency is left clicked

### DIFF
--- a/Core/CurrenciesCore.lua
+++ b/Core/CurrenciesCore.lua
@@ -90,3 +90,9 @@ end
 function L.PrepareCurrenciesMenu(eddm, self, id)
 	return L.PrepareCurrenciesMenuBase(eddm, self, id, false)
 end
+
+function L.DefaultCurrencyClickHandler(self, button)
+	if (button == "LeftButton") then
+		ToggleCharacter("TokenFrame");
+	end
+end

--- a/Core/NoAltCurrencyPlugin.lua
+++ b/Core/NoAltCurrencyPlugin.lua
@@ -182,6 +182,7 @@ function L:CreateNoAltCurrencyPlugin(params)
 		icon = ICON,
 		category = params.category,
 		version = version,
+		onClick = L.DefaultCurrencyClickHandler,
 		getButtonText = GetButtonText,
 		eventsTable = eventsTable,
 		prepareMenu = prepMenu,

--- a/Core/SimpleCurrencyPlugin.lua
+++ b/Core/SimpleCurrencyPlugin.lua
@@ -223,6 +223,7 @@ function L:CreateSimpleCurrencyPlugin(params)
 		version = version,
 		getButtonText = GetButtonText,
 		eventsTable = eventsTable,
+		onClick = L.DefaultCurrencyClickHandler,
 		prepareMenu = prepMenu,
 		savedVariables = {
 			ShowIcon = 1,


### PR DESCRIPTION
I didn't add a click handler for items, since opening bags might be weird if the items aren't in bags?

This also follows the default UI behavior for vendor windows where you can click on a currency to open the currnecy frame.