### PR TITLE
Un-deprecates the Radiant Echo and Coffer Key Shard IDs

### DIFF
--- a/Core/RemovedCurrenciesAndItems.lua
+++ b/Core/RemovedCurrenciesAndItems.lua
@@ -12,8 +12,6 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 			print("TitanCurrenciesMultiDb is nil?")
 		end
 		local removed = {
-			"TITAN_RADECHO", -- TWW S1 Radiant Echo
-			"TITAN_CFFRKYM", -- TWW S1 Coffer Key Shard
 			"TITAN_WEATHHARBCREST", -- TWW S1 Weathered Harbinger Crests
 			"TITAN_CARVEDHARBCREST", -- TWW S1 Carved Harbinger Crests
 			"TITAN_RUNEDHARBCREST", -- TWW S1 Runed Harbinger Crests


### PR DESCRIPTION
This makes it so alt data will be persistent again.