### PR TITLE
Makes menu creation consistent

### DIFF
--- a/Core/CurrenciesCore.lua
+++ b/Core/CurrenciesCore.lua
@@ -40,23 +40,7 @@ function L.PrepareCurrenciesMenuBase(eddm, self, id, hasMax, isWarband)
 	eddm.UIDropDownMenu_AddButton(L.Utils.CreateToggle(id, L["useHyperlink"], "UseHyperlink"));
 	eddm.UIDropDownMenu_AddButton(L.Utils.CreateToggle(id, L["hideInfoWhenHyperlink"], "HideInfoWhenHyperlink"));
 
-	eddm.UIDropDownMenu_AddSpace();
-
-	eddm.UIDropDownMenu_AddButton({
-		notCheckable = true,
-		text = ACE["TITAN_PANEL_MENU_HIDE"],
-		func = function()
-			TitanPanelRightClickMenu_Hide(id)
-		end
-	})
-
-	eddm.UIDropDownMenu_AddSeparator();
-
-	eddm.UIDropDownMenu_AddButton({
-		text = CLOSE,
-		notCheckable = true,
-		keepShownOnClick = false,
-	});
+	L.Utils.AddCommonMenuItems(eddm, id);
 end
 
 function L.PrepareCurrenciesMenu(eddm, self, id)

--- a/Core/NoAltCurrencyCore.lua
+++ b/Core/NoAltCurrencyCore.lua
@@ -32,21 +32,5 @@ function L.PrepareNoAltCurrenciesMenuBase(eddm, self, id, hasMax)
 	eddm.UIDropDownMenu_AddButton(L.Utils.CreateToggle(id, L["useHyperlink"], "UseHyperlink"));
 	eddm.UIDropDownMenu_AddButton(L.Utils.CreateToggle(id, L["hideInfoWhenHyperlink"], "HideInfoWhenHyperlink"));
 
-	eddm.UIDropDownMenu_AddSpace();
-
-	eddm.UIDropDownMenu_AddButton({
-		notCheckable = true,
-		text = ACE["TITAN_PANEL_MENU_HIDE"],
-		func = function()
-			TitanPanelRightClickMenu_Hide(id)
-		end
-	})
-
-	eddm.UIDropDownMenu_AddSeparator();
-
-	eddm.UIDropDownMenu_AddButton({
-		text = CLOSE,
-		notCheckable = true,
-		keepShownOnClick = false,
-	});
+	L.Utils.AddCommonMenuItems(eddm, id);
 end

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -1,5 +1,6 @@
 local _, T = ...
 
+local ACE = LibStub("AceLocale-3.0"):GetLocale(TITAN_ID, true)
 local Utils = {}
 T.Utils = Utils
 
@@ -61,6 +62,47 @@ function Utils.CreateToggle(id, text, var)
 	info.checked = TitanGetVar(id, var)
 	info.keepShownOnClick = true
 	return info
+end
+
+-- Adds the "Shift Right", "Shift Left", "Hide", and "Close" menus
+function Utils.AddCommonMenuItems(eddm, id)
+	eddm.UIDropDownMenu_AddButton({
+		text = ACE["TITAN_PANEL_SHIFT_RIGHT"],
+		func = function()
+			TitanUtils_ShiftButtonOnBarRight(id)
+		end,
+		arg1 = id,
+		keepShownOnClick = true,
+		notCheckable = true
+	});
+
+	eddm.UIDropDownMenu_AddButton({
+		text = ACE["TITAN_PANEL_SHIFT_LEFT"],
+		func = function()
+			TitanUtils_ShiftButtonOnBarLeft(id)
+		end,
+		arg1 = id,
+		keepShownOnClick = true,
+		notCheckable = true
+	});
+
+	eddm.UIDropDownMenu_AddSpace();
+
+	eddm.UIDropDownMenu_AddButton({
+		notCheckable = true,
+		text = ACE["TITAN_PANEL_MENU_HIDE"],
+		func = function()
+			TitanPanelRightClickMenu_Hide(id)
+		end
+	})
+
+	eddm.UIDropDownMenu_AddSeparator();
+
+	eddm.UIDropDownMenu_AddButton({
+		text = CLOSE,
+		notCheckable = true,
+		keepShownOnClick = false,
+	});
 end
 
 -- First argument from ElioteDropDownMenu is 'self', just ignore it

--- a/c.Legacy/BfA/TitanArtifactPower.lua
+++ b/c.Legacy/BfA/TitanArtifactPower.lua
@@ -74,37 +74,18 @@ local function OnClick(self, button)
 end
 -----------------------------------------------
 function PrepareMenu(eddm, self, id)
-    eddm.UIDropDownMenu_AddButton({
-        text = TitanPlugins[id].menuText,
-        hasArrow = false,
-        isTitle = true,
-        isUninteractable = true,
-        notCheckable = true
-    })
-
-    local info = {};
-    info.text = ACE["TITAN_CLOCK_MENU_DISPLAY_ON_RIGHT_SIDE"];
-    info.func = ToggleRightSideDisplay;
-    info.arg1 = id
-    info.checked = TitanGetVar(id, "DisplayOnRightSide");
-    info.keepShownOnClick = true
-    eddm.UIDropDownMenu_AddButton(info);
-
-    eddm.UIDropDownMenu_AddSpace();
+    eddm.UIDropDownMenu_AddButton(L.Utils.CreateTitle(id, TitanPlugins[id].menuText));
+    eddm.UIDropDownMenu_AddButton(L.Utils.CreateTitle(id, L["buttonText"]));
 
     eddm.UIDropDownMenu_AddButton({
-        notCheckable = true,
-        text = ACE["TITAN_PANEL_MENU_HIDE"],
-        func = function() TitanPanelRightClickMenu_Hide(id) end
-    })
+        text = ACE["TITAN_CLOCK_MENU_DISPLAY_ON_RIGHT_SIDE"],
+        func = L.Utils.ToggleRightSideDisplay,
+        arg1 = id,
+        checked = TitanGetVar(id, "DisplayOnRightSide"),
+        keepShownOnClick = true
+    });
 
-    eddm.UIDropDownMenu_AddSeparator();
-
-    info = {};
-    info.text = CLOSE;
-    info.notCheckable = true
-    info.keepShownOnClick = false
-    eddm.UIDropDownMenu_AddButton(info);
+    L.Utils.AddCommonMenuItems(eddm, id);
 end
 -----------------------------------------------
 L.Elib({

--- a/c.Legacy/BfA/TitanJelly.lua
+++ b/c.Legacy/BfA/TitanJelly.lua
@@ -136,45 +136,20 @@ local eventsTable = {
 }
 -----------------------------------------------
 function PrepareMenu(eddm, self, id)
-	eddm.UIDropDownMenu_AddButton({
-		text = TitanPlugins[id].menuText,
-		hasArrow = false,
-		isTitle = true,
-		isUninteractable = true,
-		notCheckable = true
-	})
+	eddm.UIDropDownMenu_AddButton(L.Utils.CreateTitle(id, TitanPlugins[id].menuText));
+	eddm.UIDropDownMenu_AddButton(L.Utils.CreateTitle(id, L["buttonText"]));
 
-	local info = {};
-	info.text = L["showbb"];
-	info.func = ToggleShowBarBalance;
-	info.arg1 = id
-	info.checked = TitanGetVar(id, "ShowBarBalance");
-	info.keepShownOnClick = true
-	eddm.UIDropDownMenu_AddButton(info);
-
-	local info = {};
-	info.text = ACE["TITAN_CLOCK_MENU_DISPLAY_ON_RIGHT_SIDE"];
-	info.func = ToggleRightSideDisplay;
-	info.arg1 = id
-	info.checked = TitanGetVar(id, "DisplayOnRightSide");
-	info.keepShownOnClick = true
-	eddm.UIDropDownMenu_AddButton(info);
-
-	eddm.UIDropDownMenu_AddSpace();
+	eddm.UIDropDownMenu_AddButton(L.Utils.CreateToggle(id, L["showbb"], "ShowBarBalance"));
 
 	eddm.UIDropDownMenu_AddButton({
-		notCheckable = true,
-		text = ACE["TITAN_PANEL_MENU_HIDE"],
-		func = function() TitanPanelRightClickMenu_Hide(id) end
-	})
+		text = ACE["TITAN_CLOCK_MENU_DISPLAY_ON_RIGHT_SIDE"],
+		func = L.Utils.ToggleRightSideDisplay,
+		arg1 = id,
+		checked = TitanGetVar(id, "DisplayOnRightSide"),
+		keepShownOnClick = true
+	});
 
-	eddm.UIDropDownMenu_AddSeparator();
-
-	info = {};
-	info.text = CLOSE;
-	info.notCheckable = true
-	info.keepShownOnClick = false
-	eddm.UIDropDownMenu_AddButton(info);
+	L.Utils.AddCommonMenuItems(eddm, id);
 end
 -----------------------------------------------
 L.Elib({


### PR DESCRIPTION
Ensured all "Display on Right Side" menus work
Consolidated the common menu item creation into a utility function
Added "Shift Right" and "Shift Left" menus to all currencies and items, for when clicking and dragging annoys you