### PR TITLE
Updates TWW S2 currencies now that crests are unlimited

### DIFF
--- a/Core/CurrenciesCore.lua
+++ b/Core/CurrenciesCore.lua
@@ -47,10 +47,14 @@ function L.PrepareCurrenciesMenu(eddm, self, id)
 	return L.PrepareCurrenciesMenuBase(eddm, self, id, false, false)
 end
 
--- I'm not sure if there are Warband currencies that have max
--- If Blizzard adds some in the future, we'll need to split this into multiple versions
+-- Warbound currency without a max
 function L.PrepareCurrenciesMenuWarband(eddm, self, id)
 	return L.PrepareCurrenciesMenuBase(eddm, self, id, false, true)
+end
+
+-- Warbound currency with a max
+function L.PrepareCurrenciesMenuWarbandMax(eddm, self, id)
+	return L.PrepareCurrenciesMenuBase(eddm, self, id, true, true)
 end
 
 function L.DefaultCurrencyClickHandler(self, button)

--- a/Core/SimpleCurrencyPlugin.lua
+++ b/Core/SimpleCurrencyPlugin.lua
@@ -290,12 +290,15 @@ function L:CreateSimpleCurrencyPlugin(params)
 	end
 
 	local prepMenu = L.PrepareCurrenciesMenu
-	local maxBarValue = nil
+	local maxBarValue = L.Utils.ifZero(currencyMaximum, nil, 0)
 	if isAccountTransferable then
-		prepMenu = L.PrepareCurrenciesMenuWarband
+		prepMenu = L.Utils.ifZero(currencyMaximum, L.PrepareCurrenciesMenuWarband, L.PrepareCurrenciesMenuWarbandMax)
+		if forceMax then
+			prepMenu = L.PrepareCurrenciesMenuWarbandMax
+			maxBarValue = 1
+		end
 	else
 		prepMenu = L.Utils.ifZero(currencyMaximum, prepMenu, L.PrepareCurrenciesMaxMenu)
-		maxBarValue = L.Utils.ifZero(currencyMaximum, nil, 0)
 		if forceMax then
 			prepMenu = L.PrepareCurrenciesMaxMenu
 			maxBarValue = 1

--- a/c.WarWithin/TitanTWWSeason2.lua
+++ b/c.WarWithin/TitanTWWSeason2.lua
@@ -14,9 +14,7 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = "TITAN_TWWS2R1CREST",
 	noCurrencyText = L["TWWSeason2"],
 	expName = L["mWarWithinS2"],
-	category = "CATEGORY_TWW",
-	forceMax = true,
-	weeklyIncrease = 90
+	category = "CATEGORY_TWW"
 })
 
 -- Carved Undermine Crests
@@ -25,9 +23,7 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = "TITAN_TWWS2R2CREST",
 	noCurrencyText = L["TWWSeason2"],
 	expName = L["mWarWithinS2"],
-	category = "CATEGORY_TWW",
-	forceMax = true,
-	weeklyIncrease = 90
+	category = "CATEGORY_TWW"
 })
 
 -- Runed Undermine Crests
@@ -36,9 +32,7 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = "TITAN_TWWS2R3CREST",
 	noCurrencyText = L["TWWSeason2"],
 	expName = L["mWarWithinS2"],
-	category = "CATEGORY_TWW",
-	forceMax = true,
-	weeklyIncrease = 90
+	category = "CATEGORY_TWW"
 })
 
 -- Gilded Undermine Crests
@@ -47,9 +41,7 @@ L:CreateSimpleCurrencyPlugin({
 	titanId = "TITAN_TWWS2R4CREST",
 	noCurrencyText = L["TWWSeason2"],
 	expName = L["mWarWithinS2"],
-	category = "CATEGORY_TWW",
-	forceMax = true,
-	weeklyIncrease = 90
+	category = "CATEGORY_TWW"
 })
 
 -- Essence of Kaja'mite (Catalyst charges, max 8)
@@ -75,6 +67,24 @@ L:CreateSimpleItemPlugin({
 L:CreateSimpleItemPlugin({
 	itemId = 235897,
 	titanId = "TITAN_RADECHO",
+	noCurrencyText = L["TWWSeason2"],
+	expName = L["mWarWithinS2"],
+	category = "CATEGORY_TWW"
+})
+
+-- Algari Token of Merit (TWW S2 version)
+L:CreateSimpleItemPlugin({
+	itemId = 230793,
+	titanId = "TITAN_ALGTOKENOFMERIT",
+	noCurrencyText = L["TWWSeason2"],
+	expName = L["mWarWithinS2"],
+	category = "CATEGORY_TWW"
+})
+
+-- Puzzling Cartel Chip
+L:CreateSimpleItemPlugin({
+	itemId = 237502,
+	titanId = "TITAN_PUZZCARTCHIP",
 	noCurrencyText = L["TWWSeason2"],
 	expName = L["mWarWithinS2"],
 	category = "CATEGORY_TWW"


### PR DESCRIPTION
Also adds the Algari Token of Merit and Puzzling Cartel Chip items. Update warbound currencies with max values to be able to show the max value on the bar (currently only Valorstones)