### PR TITLE
Allows Brewfest tokens to show the account total

### DIFF
--- a/c.Misc/TitanBrewfestToken.lua
+++ b/c.Misc/TitanBrewfestToken.lua
@@ -14,5 +14,6 @@ L:CreateSimpleItemPlugin({
 	titanId = ID,
 	noCurrencyText = L["NoToken"],
 	expName = L["mEvent"],
-	category = "CATEGORY_MISC"
+	category = "CATEGORY_MISC",
+	allowAccountTotal = true
 })


### PR DESCRIPTION
Brewfest Tokens are Bind to Warband now, so allow them to have the "Show Account Total" menu item